### PR TITLE
Doc: corrects ./plugins-local directory location

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,8 @@ providers:
 Traefik also offers a developer mode that can be used for temporary testing of plugins not hosted on GitHub.
 To use a plugin in local mode, the Traefik static configuration must define the module name (as is usual for Go packages) and a path to a [Go workspace](https://golang.org/doc/gopath_code.html#Workspaces), which can be the local GOPATH or any directory.
 
-The plugins must be placed in `./plugins-local` directory, which should be next to the Traefik binary.
+The plugins must be placed in `./plugins-local` directory, 
+which should be in the working directory of the process running the Traefik binary.
 The source code of the plugin should be organized as follows:
 
 ```


### PR DESCRIPTION
## Description

This PR corrects the documentation by stating that the `./local-plugins` directory should be in the working directory of the process which is running the Traefik binary.

see https://github.com/traefik/traefik/issues/8396